### PR TITLE
Update to Python 3.8+

### DIFF
--- a/calendrino_render.py
+++ b/calendrino_render.py
@@ -25,7 +25,7 @@ import icalendar
 import json
 from datetime import date, time, datetime, timedelta
 from operator import itemgetter
-from cgi import escape
+from html import escape
 import hashlib
 from time import sleep
 from dateutil import rrule


### PR DESCRIPTION
cgi.escape was replaced by html.escape in 3.8