### PR TITLE
Fix tzinfo being None if not given explicitly

### DIFF
--- a/calendrino_render.py
+++ b/calendrino_render.py
@@ -93,6 +93,8 @@ def expand_event(event, verbose=False):
 		event_start = event['DTSTART'].dt
 		dtdelta =  event['DTEND'].dt - event_start
 		tz = getattr(event_start, 'tzinfo', None)
+		if not tz:
+		    tz = localtz
 		if verbose:
 			print("    expand_event(): tz is %s --- %s" % (tz, tz.__class__))
 		if isinstance(event_start, datetime):


### PR DESCRIPTION
Hi,
I encountered a problem when using your renderer on Emacs Org Mode output.

It seems like the code assumes that a series of events has always a specified timezone. As the config already allows to specify a default timezone, I suggest just using this.